### PR TITLE
Add generator duplication and collapsible config

### DIFF
--- a/app/(root)/generators/actions.ts
+++ b/app/(root)/generators/actions.ts
@@ -46,3 +46,15 @@ export async function deleteGenerator(id: number) {
     await repo.delete(id);
     revalidatePath("/generators");
 }
+
+export async function duplicateGenerator(id: number) {
+    const repo = getGeneratorRepository();
+    const gen = await repo.get(id);
+    if (!gen) throw new Error(`Generator ${id} not found`);
+    await repo.create({
+        name: `Copy of ${gen.name}`,
+        type: gen.type,
+        config: gen.config,
+    });
+    revalidatePath("/generators");
+}

--- a/lib/repositories/generatorRepository.ts
+++ b/lib/repositories/generatorRepository.ts
@@ -21,6 +21,8 @@ export interface GeneratorRunRecord {
 export interface IGeneratorRepository {
     list(type?: GeneratorType): Promise<GeneratorRecord[]>;
 
+    get(id: number): Promise<GeneratorRecord | null>;
+
     create(input: {
         name: string;
         type: GeneratorType;

--- a/lib/repositories/impl/drizzleGeneratorRepo.ts
+++ b/lib/repositories/impl/drizzleGeneratorRepo.ts
@@ -27,6 +27,16 @@ export class DrizzleGeneratorRepository implements IGeneratorRepository {
         return r as GeneratorRecord[];
     }
 
+    async get(id: number): Promise<GeneratorRecord | null> {
+        const r = await db
+            .select()
+            .from(generators)
+            .where(eq(generators.id, id))
+            .limit(1)
+            .all();
+        return (r[0] as GeneratorRecord | undefined) ?? null;
+    }
+
     async create(input: {
         name: string;
         type: GeneratorType;


### PR DESCRIPTION
## Summary
- allow generators to be duplicated via new action and UI button
- make generator config section collapsible by default
- expose `get` method on generator repository for lookups

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot read properties of undefined (reading 'execute'))*

------
https://chatgpt.com/codex/tasks/task_e_6844b46b1e5c832888b2632f91758182