### PR TITLE
Add worker run error repository method and fix UI

### DIFF
--- a/app/(root)/worker/page.tsx
+++ b/app/(root)/worker/page.tsx
@@ -1,0 +1,141 @@
+"use client";
+import React from "react";
+import {
+    Box,
+    Heading,
+    Table,
+    Thead,
+    Tbody,
+    Tr,
+    Th,
+    Td,
+    Accordion,
+    AccordionItem,
+    AccordionButton,
+    AccordionPanel,
+    AccordionIcon,
+    Text,
+} from "@chakra-ui/react";
+import useSWR from "swr";
+import type { WorkerRunRecord } from "@/lib/repositories";
+import { RunProgressBar } from "@/components/RunProgressBar";
+
+export const metadata = { title: "Worker status" };
+
+interface RunsResponse {
+    page: WorkerRunRecord[];
+    errors?: Record<string, { id: number; name: string; error: string }[]>;
+}
+
+const fetcher = (url: string) => fetch(url).then(r => r.json());
+
+export default function WorkerRunsPage() {
+    const { data } = useSWR<RunsResponse>(
+        "/api/worker-runs?limit=20&withErrors=1",
+        fetcher,
+        { refreshInterval: 30000 },
+    );
+
+    const runs = data?.page ?? [];
+    const errors = data?.errors ?? {};
+
+    const formatDuration = (run: WorkerRunRecord) => {
+        const end = run.endedAt ? new Date(run.endedAt) : new Date();
+        const start = new Date(run.startedAt);
+        const ms = end.getTime() - start.getTime();
+        const m = Math.floor(ms / 60000);
+        const s = Math.floor((ms % 60000) / 1000);
+        return `${m}m ${s}s`;
+    };
+
+    return (
+        <Box p={6} maxW="6xl" mx="auto">
+            <Heading mb={8}>Worker Runs</Heading>
+            <Table variant="simple">
+                <Thead>
+                    <Tr>
+                        <Th>Started</Th>
+                        <Th>Ended</Th>
+                        <Th>Duration</Th>
+                        <Th w="40%">Generators</Th>
+                        <Th>Posts</Th>
+                    </Tr>
+                </Thead>
+                <Tbody>
+                    {runs.map(run => {
+                        const key = new Date(run.startedAt).getTime();
+                        const errList = errors[key];
+                        return (
+                            <React.Fragment key={key}>
+                                <Tr>
+                                    <Td>
+                                        {new Date(
+                                            run.startedAt,
+                                        ).toLocaleString()}
+                                    </Td>
+                                    <Td>
+                                        {run.endedAt
+                                            ? new Date(
+                                                  run.endedAt,
+                                              ).toLocaleString()
+                                            : ""}
+                                    </Td>
+                                    <Td>{formatDuration(run)}</Td>
+                                    <Td>
+                                        <RunProgressBar
+                                            successCount={run.successCount}
+                                            failCount={run.failCount}
+                                            total={run.numGenerators}
+                                        />
+                                    </Td>
+                                    <Td>{run.postCount}</Td>
+                                </Tr>
+                                {errList && errList.length > 0 && (
+                                    <Tr>
+                                        <Td colSpan={5} p={0}>
+                                            <Accordion allowToggle>
+                                                <AccordionItem border="0">
+                                                    <h2>
+                                                        <AccordionButton>
+                                                            <Box
+                                                                flex="1"
+                                                                textAlign="left"
+                                                            >
+                                                                Errors (
+                                                                {errList.length}
+                                                                )
+                                                            </Box>
+                                                            <AccordionIcon />
+                                                        </AccordionButton>
+                                                    </h2>
+                                                    <AccordionPanel pb={4}>
+                                                        {errList.map(e => (
+                                                            <Box
+                                                                key={e.id}
+                                                                mb={4}
+                                                            >
+                                                                <Text
+                                                                    fontWeight="bold"
+                                                                    mb={1}
+                                                                >
+                                                                    {e.name}
+                                                                </Text>
+                                                                <Text whiteSpace="pre-wrap">
+                                                                    {e.error}
+                                                                </Text>
+                                                            </Box>
+                                                        ))}
+                                                    </AccordionPanel>
+                                                </AccordionItem>
+                                            </Accordion>
+                                        </Td>
+                                    </Tr>
+                                )}
+                            </React.Fragment>
+                        );
+                    })}
+                </Tbody>
+            </Table>
+        </Box>
+    );
+}

--- a/app/api/worker-runs/latest/route.ts
+++ b/app/api/worker-runs/latest/route.ts
@@ -1,0 +1,10 @@
+import { getWorkerRunRepository } from "@/lib/repositories";
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+    const repo = getWorkerRunRepository();
+    const run = await repo.getLast();
+    return NextResponse.json(run);
+}

--- a/app/api/worker-runs/route.ts
+++ b/app/api/worker-runs/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+    getWorkerRunRepository,
+    getGeneratorRepository,
+} from "@/lib/repositories";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+    const { searchParams } = new URL(req.url);
+    const limit = Math.min(
+        parseInt(searchParams.get("limit") ?? "20", 10),
+        100,
+    );
+    const offset = parseInt(searchParams.get("offset") ?? "0", 10);
+    const withErrors = searchParams.get("withErrors") === "1";
+
+    const repo = getWorkerRunRepository();
+    const genRepo = getGeneratorRepository();
+    const page = await repo.list(limit, offset);
+
+    let errors:
+        | Record<string, { id: number; name: string; error: string }[]>
+        | undefined;
+    if (withErrors && page.length > 0) {
+        errors = {};
+        for (const run of page) {
+            const rows = await genRepo.listRunErrors(run.startedAt);
+            if (rows.length) {
+                errors[run.startedAt.getTime()] = rows;
+            }
+        }
+    }
+
+    return NextResponse.json({
+        page,
+        errors,
+        next: page.length < limit ? null : offset + page.length,
+    });
+}

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -1,6 +1,7 @@
 import { Box, Flex, Grid, IconButton, Link, Heading } from "@chakra-ui/react";
 import { FiBookmark, FiSettings } from "react-icons/fi";
 import NextLink from "next/link";
+import WorkerStatusIndicator from "./WorkerStatusIndicator";
 
 export function NavBar() {
     return (
@@ -17,7 +18,7 @@ export function NavBar() {
             borderBottom="1px solid var(--chakra-colors-border)"
             zIndex="banner"
         >
-            {/* 1 ▸ LEFT slot — bookmark icon on mobile, invisible placeholder on desktop */}
+            {/* 1 ▸ LEFT slot — bookmark + status on mobile, placeholder on desktop */}
             <LeftPad />
 
             {/* 2 ▸ CENTRE — cursive, lowercase title */}
@@ -34,13 +35,17 @@ export function NavBar() {
                 </Link>
             </Heading>
 
-            {/* 3 ▸ RIGHT slot — settings icon (always) + bookmark on desktop */}
+            {/* 3 ▸ RIGHT slot — settings icon (always) + bookmark and status on desktop */}
             <Flex justify="flex-end" gap="2">
                 {/* show the bookmark here only ≥ md */}
                 <NavIcon
                     href="/saved"
                     label="Saved posts"
                     icon={<FiBookmark />}
+                    display={{ base: "none", md: "inline-flex" }}
+                />
+                {/* show worker status here only ≥ md */}
+                <WorkerStatusIndicator
                     display={{ base: "none", md: "inline-flex" }}
                 />
                 <NavIcon
@@ -63,6 +68,9 @@ function LeftPad() {
                 href="/saved"
                 label="Saved posts"
                 icon={<FiBookmark />}
+                display={{ base: "inline-flex", md: "none" }}
+            />
+            <WorkerStatusIndicator
                 display={{ base: "inline-flex", md: "none" }}
             />
             <Box w="40px" display={{ base: "none", md: "block" }} />

--- a/components/RunProgressBar.tsx
+++ b/components/RunProgressBar.tsx
@@ -1,0 +1,26 @@
+import { Box, HStack } from "@chakra-ui/react";
+interface Props {
+    successCount: number;
+    failCount: number;
+    total: number;
+}
+
+export function RunProgressBar({ successCount, failCount, total }: Props) {
+    const safeTotal = Math.max(total, 1);
+    const successPct = (successCount / safeTotal) * 100;
+    const failPct = (failCount / safeTotal) * 100;
+    const pendingPct = 100 - successPct - failPct;
+
+    return (
+        <HStack w="full" h="4" spacing={0} borderRadius="sm" overflow="hidden">
+            <Box bg="green.500" w={`${successPct}%`} h="full" />
+            <Box bg="red.500" w={`${failPct}%`} h="full" />
+            <Box
+                bg="gray.300"
+                _dark={{ bg: "gray.600" }}
+                w={`${pendingPct}%`}
+                h="full"
+            />
+        </HStack>
+    );
+}

--- a/components/WorkerRunPopoverContent.tsx
+++ b/components/WorkerRunPopoverContent.tsx
@@ -1,0 +1,51 @@
+"use client";
+import { Stack, Text, Link } from "@chakra-ui/react";
+import NextLink from "next/link";
+import type { WorkerRunRecord } from "@/lib/repositories";
+import { RunProgressBar } from "./RunProgressBar";
+
+function durationMs(start: Date, end: Date) {
+    return end.getTime() - start.getTime();
+}
+
+function formatDuration(ms: number) {
+    const m = Math.floor(ms / 60000);
+    const s = Math.floor((ms % 60000) / 1000);
+    return `${m}m ${s}s`;
+}
+
+export function WorkerRunPopoverContent({
+    run,
+}: {
+    run: WorkerRunRecord | null;
+}) {
+    if (!run) return <Text>No runs yet</Text>;
+    const end = run.endedAt ?? new Date();
+    const pending = run.numGenerators - run.successCount - run.failCount;
+    return (
+        <Stack spacing={3} fontSize="sm">
+            <Text>
+                <strong>Started:</strong> {run.startedAt.toLocaleString()}
+            </Text>
+            <Text>
+                <strong>Duration:</strong>{" "}
+                {formatDuration(durationMs(run.startedAt, end))}
+            </Text>
+            <RunProgressBar
+                successCount={run.successCount}
+                failCount={run.failCount}
+                total={run.numGenerators}
+            />
+            <Text>
+                {run.successCount} succeeded, {run.failCount} failed, {pending}{" "}
+                pending
+            </Text>
+            <Text>
+                <strong>Posts:</strong> {run.postCount}
+            </Text>
+            <Link as={NextLink} href="/worker" color="teal.500">
+                Worker status page
+            </Link>
+        </Stack>
+    );
+}

--- a/components/WorkerStatusIndicator.tsx
+++ b/components/WorkerStatusIndicator.tsx
@@ -1,0 +1,79 @@
+"use client";
+import {
+    CircularProgress,
+    CircularProgressLabel,
+    IconButton,
+    Popover,
+    PopoverBody,
+    PopoverContent,
+    PopoverTrigger,
+} from "@chakra-ui/react";
+import { useDisclosure } from "@chakra-ui/react";
+import { FiCheck, FiAlertCircle } from "react-icons/fi";
+import useSWR from "swr";
+import type { WorkerRunRecord } from "@/lib/repositories";
+import { WorkerRunPopoverContent } from "./WorkerRunPopoverContent";
+
+const fetcher = (url: string) => fetch(url).then(r => r.json());
+
+interface Props {
+    display?: Record<string, string>;
+}
+
+export default function WorkerStatusIndicator({ display }: Props) {
+    const { data } = useSWR<WorkerRunRecord | null>(
+        "/api/worker-runs/latest",
+        fetcher,
+        { refreshInterval: 30000 },
+    );
+    const { isOpen, onOpen, onClose } = useDisclosure();
+    const run = data ?? null;
+
+    let value = 0;
+    let color = "gray.400";
+    let label: React.ReactNode = null;
+
+    if (run) {
+        if (run.endedAt) {
+            value = 100;
+            color = run.failCount > 0 ? "red.500" : "green.500";
+            label = run.failCount > 0 ? <FiAlertCircle /> : <FiCheck />;
+        } else {
+            value =
+                ((run.successCount + run.failCount) / run.numGenerators) * 100;
+            color = "blue.500";
+        }
+    }
+
+    return (
+        <Popover
+            isOpen={isOpen}
+            onOpen={onOpen}
+            onClose={onClose}
+            placement="bottom-start"
+        >
+            <PopoverTrigger>
+                <IconButton
+                    aria-label="Worker status"
+                    variant="ghost"
+                    size="md"
+                    minW="40px"
+                    display={display}
+                >
+                    <CircularProgress value={value} size="24px" color={color}>
+                        {label && (
+                            <CircularProgressLabel>
+                                {label}
+                            </CircularProgressLabel>
+                        )}
+                    </CircularProgress>
+                </IconButton>
+            </PopoverTrigger>
+            <PopoverContent w="xs">
+                <PopoverBody>
+                    <WorkerRunPopoverContent run={run} />
+                </PopoverBody>
+            </PopoverContent>
+        </Popover>
+    );
+}

--- a/lib/repositories/generatorRepository.ts
+++ b/lib/repositories/generatorRepository.ts
@@ -47,5 +47,12 @@ export interface IGeneratorRepository {
 
     getLastRun(id: number): Promise<GeneratorRunRecord | null>;
 
+    /**
+     * List any generator errors for the worker run that started at `start`.
+     */
+    listRunErrors(
+        start: Date,
+    ): Promise<{ id: number; name: string; error: string }[]>;
+
     delete(id: number): Promise<void>;
 }

--- a/lib/repositories/impl/drizzleGeneratorRepo.ts
+++ b/lib/repositories/impl/drizzleGeneratorRepo.ts
@@ -108,6 +108,25 @@ export class DrizzleGeneratorRepository implements IGeneratorRepository {
         return (r[0] as GeneratorRunRecord | undefined) ?? null;
     }
 
+    async listRunErrors(start: Date) {
+        const rows = await db
+            .select({
+                id: generatorRuns.generatorId,
+                name: generators.name,
+                error: generatorRuns.error,
+            })
+            .from(generatorRuns)
+            .innerJoin(generators, eq(generatorRuns.generatorId, generators.id))
+            .where(
+                and(
+                    eq(generatorRuns.startTs, start),
+                    eq(generatorRuns.outcome, "error"),
+                ),
+            )
+            .all();
+        return rows as { id: number; name: string; error: string }[];
+    }
+
     async delete(id: number): Promise<void> {
         await db.delete(generators).where(eq(generators.id, id)).run();
     }


### PR DESCRIPTION
## Summary
- show start and end times for worker runs
- move generator error query into repository
- update progress bar props

## Testing
- `npm run fmt`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844b3b2d51883289a5101f9c0fd990a