### PR TITLE
Fix sticky navbar regression

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -47,7 +47,6 @@ export function NavBar() {
             bg="var(--chakra-colors-bg)" /* adapts to color‑mode via CSS var */
             borderBottom="1px solid var(--chakra-colors-border)"
             zIndex="banner"
-            pos="relative"
         >
             {/* LEFT - saved posts */}
             <Flex flex="1" gap="2">


### PR DESCRIPTION
## Summary
- keep NavBar positioned sticky instead of relative

## Testing
- `npm run lint`
- `npm run build` *(fails: TypeError in Next.js build)*

------
https://chatgpt.com/codex/tasks/task_e_68560ba746b483289b78c916203d9a04