### PR TITLE
Fix worker build with external jsdom

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "dev": "next dev",
         "build": "next build",
-        "build:worker": "npx esbuild worker/index.ts --bundle --format=cjs --platform=node --target=node20 --external:wordpos --external:underscore --external:zod --outfile=build/worker.js",
+        "build:worker": "npx esbuild worker/index.ts --bundle --format=cjs --platform=node --target=node20 --external:wordpos --external:underscore --external:zod --external:jsdom --outfile=build/worker.js",
         "start": "next start",
         "lint": "next lint",
         "fmt": "npx prettier --write ."


### PR DESCRIPTION
## Summary
- patch worker build script to treat jsdom as external

## Testing
- `npm run build:worker`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685724d65c088328b1391ea3bd129dd0